### PR TITLE
Push to docker hub

### DIFF
--- a/.github/version_extractor.sh
+++ b/.github/version_extractor.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# This is a small helper script used to extract the Caddy version numbers used
+# for tagging the final Docker container. This script expects one input
+# argument, and that is the path to the Dockerfile of interest.
+#
+# The output from this script is a list of key=values suitable for GITHUB_ENV
+
+if [ ! -f "${1}" ]; then
+    >&2 echo "File '${1}' was not found"
+    exit 1
+fi
+
+caddy_major=$(sed -n -r -e 's/^FROM caddy:([1-9])\.[0-9]+\.[0-9]+$/\1/p' "${1}")
+caddy_minor=$(sed -n -r -e 's/^FROM caddy:[1-9]\.([0-9]+)\.[0-9]+$/\1/p' "${1}")
+caddy_patch=$(sed -n -r -e 's/^FROM caddy:[1-9]\.[0-9]+\.([0-9]+)$/\1/p' "${1}")
+echo "CADDY_MAJOR=${caddy_major}"
+echo "CADDY_MINOR=${caddy_minor}"
+echo "CADDY_PATCH=${caddy_patch}"
+if ! [ -n "${caddy_major}" -a -n "${caddy_minor}" -a -n "${caddy_patch}" ]; then
+    >&2 echo "Could not extract all expected values."
+    exit 1
+fi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,19 +8,23 @@ on:
       - "Dockerfile*"
       - ".github/workflows/**"
   pull_request:
-    branches: 
+    branches:
       - "main"
     paths:
       - "Dockerfile*"
       - ".github/workflows/**"
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag axistools/caddy-bundle:$(date +%s)
+      - uses: actions/checkout@v3
+
+      - name: Extract the Caddy version numbers from the Dockerfile
+        run: bash .github/version_extractor.sh ./Dockerfile >> $GITHUB_ENV
+
+      - name: Build the Docker image
+        run: |
+          docker build . --file Dockerfile \
+            --tag "axistools/caddy-bundle:${{ env.CADDY_MAJOR }}.${{ env.CADDY_MINOR }}.${{ env.CADDY_PATCH }}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,18 @@ jobs:
       - name: Extract the Caddy version numbers from the Dockerfile
         run: bash .github/version_extractor.sh ./Dockerfile >> $GITHUB_ENV
 
-      - name: Build the Docker image
-        run: |
-          docker build . --file Dockerfile \
-            --tag "axistools/caddy-bundle:${{ env.CADDY_MAJOR }}.${{ env.CADDY_MINOR }}.${{ env.CADDY_PATCH }}"
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            axistools/caddy-bundle:${{ env.CADDY_MAJOR }}.${{ env.CADDY_MINOR }}.${{ env.CADDY_PATCH }}
+            axistools/caddy-bundle:${{ env.CADDY_MAJOR }}.${{ env.CADDY_MINOR }}
+            axistools/caddy-bundle:${{ env.CADDY_MAJOR }}
+            axistools/caddy-bundle:latest


### PR DESCRIPTION
This change adds a helper script to the github workflows that extracts the caddy version from the Dockerfile. The Caddy version will later be used to tag the resulting docker image.
